### PR TITLE
Fix for issue #9

### DIFF
--- a/Assets/QuickButtons/Code/Editor/QuickButtonDrawer.cs
+++ b/Assets/QuickButtons/Code/Editor/QuickButtonDrawer.cs
@@ -54,9 +54,19 @@ namespace RoboRyanTron.QuickButtons.Editor
                 string[] nameAndIndex = props[i].Split('[', ']');
                 int arrayIndex = nameAndIndex.Length <= 1 ? -1 :
                     int.Parse(nameAndIndex[1]);
-                
-                FieldInfo field = t?.GetField(nameAndIndex[0], flags);
-                obj = field?.GetValue(obj);
+
+                // Search in base classes to resolve private types
+                Type currentType = t;
+                FieldInfo field = null;
+                while (field == null && currentType != null)
+                {
+                    field = currentType.GetField(nameAndIndex[0], flags);
+                    if (field == null)
+                        currentType = currentType.BaseType;
+                    else
+                        obj = field.GetValue(obj);
+                }
+                if (field == null) obj = null;
                 t = field?.FieldType;
 
                 if (!skipList)


### PR DESCRIPTION
Private quick buttons will no longer error in inherited classes when clicked. When resolving button invocation targets, GetObjectForProperty will search upwards on base types whenever a field defined by the serialized property can not be resolved